### PR TITLE
version 4.0.1

### DIFF
--- a/inc/class-spotim-i18n.php
+++ b/inc/class-spotim-i18n.php
@@ -1,0 +1,46 @@
+<?php
+// Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * SpotIM_i18n
+ *
+ * Plugin translation files.
+ *
+ * @since 4.0.1
+ */
+class SpotIM_i18n {
+
+    /**
+     * Constructor
+     *
+     * Get things started.
+     *
+     * @since 4.0.1
+     *
+     * @access public
+     */
+    public function __construct() {
+
+        add_action( 'plugins_loaded', array( $this, 'load_textdomain' ) );
+
+    }
+
+    /**
+     * Load text domain
+     *
+     * Load the plugin translation text domain.
+     *
+     * @since 4.0.1
+     *
+     * @access public
+     */
+    public function load_textdomain() {
+
+        load_plugin_textdomain( 'spotim-comments' );
+
+    }
+
+}

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Spot.IM, ramiy, maor, rzvagelsky, idanm
 Tags: Comment, comment form, commenting, comments, comment author, comment form, comment system, comment template, comments box, community, discuss, discussion, discussions, commenter, live update, real time, realtime, real-time, Spot.IM, reply, social login, widget, social, moderation, community, communities, engagement, Facebook, profile, sharing, newsfeed, chat, chat interface, notification, notifications, SEO, retention, pageviews, email alerts, direct message, direct messaging, group message, group messaging, content, content circulation, UGC, user generated content
 Requires at least: 4.0
 Tested up to: 4.7
-Stable tag: 4.0.0
+Stable tag: 4.0.1
 License: GPLv2 or later
 License URI: license.txt
 
@@ -210,6 +210,9 @@ We know managing a website can get complicated. That’s why we made Spot.IM eas
 You are also always more than welcome to contact our team at support@spot.im. We’ll be glad to help.
 
 == Changelog ==
+
+= 4.0.1 =
+* i18n: Load text domain using `load_plugin_textdomain()` to fix the error message on translate.wordpress.org
 
 = 4.0.0 =
 * New UI for Spot.IM settings page with tabs (General, Display, Import and Export tabs).

--- a/spotim-comments.php
+++ b/spotim-comments.php
@@ -3,7 +3,7 @@
  * Plugin Name:         Spot.IM Comments
  * Plugin URI:          https://wordpress.org/plugins/spotim-comments/
  * Description:         Real-time comments widget turns your site into its own content-circulating ecosystem.
- * Version:             4.0.0
+ * Version:             4.0.1
  * Author:              Spot.IM
  * Author URI:          https://github.com/SpotIM
  * License:             GPLv2
@@ -21,6 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 require_once( 'inc/helpers/class-spotim-form.php' );
 require_once( 'inc/helpers/class-spotim-message.php' );
 require_once( 'inc/helpers/class-spotim-comment.php' );
+require_once( 'inc/class-spotim-i18n.php' );
 require_once( 'inc/class-spotim-endpoint.php' );
 require_once( 'inc/class-spotim-export.php' );
 require_once( 'inc/class-spotim-import.php' );
@@ -66,6 +67,7 @@ class WP_SpotIM {
     protected function __construct() {
         $this->options = SpotIM_Options::get_instance();
 
+        new SpotIM_i18n();
         new SpotIM_Cron( $this->options );
 
         if ( is_admin() ) {


### PR DESCRIPTION
Fix the error message on translate.wordpress.org using `load_plugin_textdomain()` function